### PR TITLE
Corrected typo in Read-Host in the PS Module

### DIFF
--- a/Powershell/PasswdGen.psm1
+++ b/Powershell/PasswdGen.psm1
@@ -107,7 +107,7 @@ function Get-StrongPw {
     #>
     if($args.length -eq 0) { return }
 
-    $key = Read-Host -Prompt "Encryption key:" -AsSecureString
+    $key = Read-Host -Prompt "Encryption key" -AsSecureString
     $strkey = [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($key))
 
     foreach ($i in $args)
@@ -148,7 +148,7 @@ function Get-StdPw {
     #>
     if($args.length -eq 0) { return }
 
-    $key = Read-Host -Prompt "Encryption key:" -AsSecureString
+    $key = Read-Host -Prompt "Encryption key" -AsSecureString
     $strkey = [Runtime.InteropServices.Marshal]::PtrToStringAuto([Runtime.InteropServices.Marshal]::SecureStringToBSTR($key))
 
     foreach ($i in $args)


### PR DESCRIPTION
Read-Host appends a colon to whatever the string is in the -Prompt
argument, so there's no need to include a colon there.