### PR TITLE
Add support for macOS and zsh

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -8,6 +8,7 @@ There are two password generators:
 Here there are three versions of each of these generators:
 
 *   Bash
+*   zsh
 *   Powershell
 *   Standalone HTML + Javascript
 
@@ -20,6 +21,27 @@ Using the bash version
         source passwdgen.bash
 
 Next time you start bash, you can use the following commands:
+
+    strongpw site1 [site2...]
+    stdpw    site1 [site2...]
+
+You will be prompted for the master key. Then, if there is only one site
+specified, you will get the password into the clipboard, else passwords will be
+echoed in your terminal.
+
+An additional verification code will appear, that will be always the same
+(depends only on the typed-in master key). It can help you detect whether you
+mistyped your key.
+
+Using the zsh version
+----------------------
+
+*   copy `passwdgen.zsh` from the `zsh` subdirectory into your home directory
+*   add the following line to your `.zshrc`:
+
+        source passwdgen.zsh
+
+Next time you start zsh, you can use the following commands:
 
     strongpw site1 [site2...]
     stdpw    site1 [site2...]

--- a/bash/passwdgen.bash
+++ b/bash/passwdgen.bash
@@ -19,7 +19,7 @@ ss64pwd_sha256sum() {
 }
 
 ss64pwd_find_clipboard_manager() {
-    which gclip || which pbcopy
+    which gclip pbxcopy | grep -v 'not found'
 }
 
 ss64pwd_to_clipboard() {

--- a/bash/passwdgen.bash
+++ b/bash/passwdgen.bash
@@ -19,7 +19,7 @@ ss64pwd_sha256sum() {
 }
 
 ss64pwd_find_clipboard_manager() {
-    which gclip pbxcopy | grep -v -m 1 'not found'
+    which gclip pbcopy | grep -v -m 1 'not found'
 }
 
 ss64pwd_to_clipboard() {

--- a/bash/passwdgen.bash
+++ b/bash/passwdgen.bash
@@ -19,7 +19,7 @@ ss64pwd_sha256sum() {
 }
 
 ss64pwd_find_clipboard_manager() {
-    which gclip pbxcopy | grep -v 'not found'
+    which gclip pbxcopy | grep -v -m 1 'not found'
 }
 
 ss64pwd_to_clipboard() {

--- a/bash/passwdgen.bash
+++ b/bash/passwdgen.bash
@@ -18,11 +18,15 @@ ss64pwd_sha256sum() {
     fi
 }
 
+ss64pwd_find_clipboard_manager() {
+    which gclip || which pbcopy
+}
+
 ss64pwd_to_clipboard() {
-    if (($1==1)) && which gclip &> /dev/null
+    if (($1==1)) && clm=$(ss64pwd_find_clipboard_manager)
     then
-        gclip # consumes stdin
-        echo '(in clipboard)'
+        eval ${clm} # consumes stdin
+        echo -n '(in clipboard)'
     else
         cat # consumes stdin
     fi
@@ -48,6 +52,7 @@ strongpw() {
             ss64pwd_to_clipboard $one_arg
         shift
     done
+    echo
     echo -n 'Verification code: '
     echo -n ":$key:" | ss64pwd_sha256sum | perl -ne "s/([0-9a-f]{2})/print chr hex \$1/gie" | base64 | tr +/ Ea | cut -b 1-20
 }

--- a/zsh/passwdgen.zsh
+++ b/zsh/passwdgen.zsh
@@ -19,8 +19,12 @@ ss64pwd_sha256sum() {
     fi
 }
 
+ss64pwd_find_clipboard_manager() {
+    which gclip pbcopy | grep -v 'not found'
+}
+
 ss64pwd_to_clipboard() {
-    if (($1==1)) && (clm=$(which gclip) || clm=$(which pbcopy))
+    if (($1==1)) && clm=$(ss64pwd_find_clipboard_manager)
     then
         eval ${clm} # consumes stdin
         echo -n '(in clipboard)'

--- a/zsh/passwdgen.zsh
+++ b/zsh/passwdgen.zsh
@@ -20,7 +20,7 @@ ss64pwd_sha256sum() {
 }
 
 ss64pwd_find_clipboard_manager() {
-    which gclip pbcopy | grep -v 'not found'
+    which gclip pbcopy | grep -v -m 1 'not found'
 }
 
 ss64pwd_to_clipboard() {

--- a/zsh/passwdgen.zsh
+++ b/zsh/passwdgen.zsh
@@ -1,0 +1,80 @@
+# The original script comes from https://github.com/salsifis/ss64-password-generators
+# Modificatied to adapt for zsh and macOS clipboard
+#
+ss64pwd_sha1sum() {
+    if which sha1sum &> /dev/null
+    then
+        sha1sum # consumes stdin
+    else
+        shasum -a 1 # consumes stdin
+    fi
+}
+
+ss64pwd_sha256sum() {
+    if which sha256sum &> /dev/null
+    then
+        sha256sum # consumes stdin
+    else
+        shasum -a 256 # consumes stdin
+    fi
+}
+
+ss64pwd_to_clipboard() {
+    if (($1==1)) && (clm=$(which gclip) || clm=$(which pbcopy))
+    then
+        eval ${clm} # consumes stdin
+        echo -n '(in clipboard)'
+    else
+        cat # consumes stdin
+    fi
+}
+
+strongpw() {
+    [[ "$1" != "" ]] || return
+    one_arg=0
+    (($#==1)) && one_arg=1
+    read -rs 'key?Encryption key: '
+    [[ "$key" != "" ]] || return
+    echo ''
+    while [[ "$1" != "" ]]
+    do
+        echo -n "Password for $1: " # line break
+        echo -n "$key:$1"                                    |
+            ss64pwd_sha256sum                                |
+            perl -ne "s/([0-9a-f]{2})/print chr hex \$1/gie" |
+            base64                                           |
+            tr +/ Ea                                         |
+            cut -b 1-20                                      |
+            xargs printf %s                                  |
+            ss64pwd_to_clipboard $one_arg
+        shift
+    done
+    echo
+    echo -n 'Verification code: '
+    echo -n ":$key:" | ss64pwd_sha256sum | perl -ne "s/([0-9a-f]{2})/print chr hex \$1/gie" | base64 | tr +/ Ea | cut -b 1-20
+}
+
+stdpw() {
+    [[ "$1" != "" ]] || return
+    one_arg=0
+    (($#==1)) && one_arg=1
+    read -rs 'key?Encryption key: '
+    [[ "$key" != "" ]] || return
+    echo ''
+    while [[ "$1" != "" ]]
+    do
+        echo -n "Password for $1: " # line break
+        echo -n "$key:$1"                                    |
+            ss64pwd_sha1sum                                  |
+            perl -ne "s/([0-9a-f]{2})/print chr hex \$1/gie" |
+            base64                                           |
+            cut -b 1-8                                       |
+            perl -pe "s/$/1a/"                               |
+            xargs printf %s                                  |
+            ss64pwd_to_clipboard $one_arg
+        shift
+    done
+    echo
+    echo -n 'Verification code: '
+    echo -n ":$key:" | ss64pwd_sha256sum | perl -ne "s/([0-9a-f]{2})/print chr hex \$1/gie" | base64 | tr +/ Ea | cut -b 1-20
+}


### PR DESCRIPTION
This merge request: 

- adds support for macOS pasteboard to the bash script (added a function which can be used to include other clipboard managers easily. Just add them as parameters to the `which` command in `ss64pwd_find_clipboard_manager()` function, the first one found will be used.)
- adds a script to support zsh (fixes the compatibility issues with `read` in zsh)
- updates the main README file with instructions for using the zsh script